### PR TITLE
Add configurability for default title texts

### DIFF
--- a/window-buttons-with-title@fmete/applet.js
+++ b/window-buttons-with-title@fmete/applet.js
@@ -75,7 +75,9 @@ WindowButtonApplet.prototype = {
 	this.settings.bindProperty(Settings.BindingDirection.IN,"icon-middle-button-action", "iconMiddleButtonAction", this.on_settings_changed,null); 
 	this.settings.bindProperty(Settings.BindingDirection.IN,"show-panels", "show_panels",this.on_settings_changed,null);
 	this.settings.bindProperty(Settings.BindingDirection.IN,"text-mode", "textMode",this.on_settings_changed,null);		  
-	this.settings.bindProperty(Settings.BindingDirection.IN,"only-maximized", "onlyMaximized",this.on_settings_changed,null);	
+	this.settings.bindProperty(Settings.BindingDirection.IN,"only-maximized", "onlyMaximized",this.on_settings_changed,null);
+	this.settings.bindProperty(Settings.BindingDirection.IN,"title-desktop-text", "titleDesktopText",this.on_settings_changed,null);
+	this.settings.bindProperty(Settings.BindingDirection.IN,"title-nowindow-text", "titleNowindowText",this.on_settings_changed,null);
 	this.settings.bindProperty(Settings.BindingDirection.IN,"title-font", "titleFont",this.on_settings_changed,null);
 	this.settings.bindProperty(Settings.BindingDirection.IN,"title-font-style", "titleFontStyle",this.on_settings_changed,null);
 	this.settings.bindProperty(Settings.BindingDirection.IN,"title-font-color", "titleFontColor",this.on_settings_changed,null);
@@ -180,7 +182,7 @@ WindowButtonApplet.prototype = {
    				     reactive: true });
                                      
            
-            let label = new St.Label({ text : 'No Active Window', style_class: 'window-list-item'});
+            let label = new St.Label({ text : this.titleNowindowText.toString(), style_class: 'window-list-item'});
 	       
             
             this.button['title'].set_child(label);
@@ -578,7 +580,7 @@ WindowButtonApplet.prototype = {
 		    //this.actor.add(this.button['title']);
 		    
 		    }else{
-		     let t=_("Desktop");
+		     let t=_(this.titleDesktopText.toString());
 		     this.button['title'].get_child().set_text("  " + t.toString());
 		    
 		    }

--- a/window-buttons-with-title@fmete/settings-schema.json
+++ b/window-buttons-with-title@fmete/settings-schema.json
@@ -43,6 +43,16 @@
       "default" : false,
       "description": "Show applet (active buttons-title-icon on this instance) only active window maximized"
    },
+   "title-desktop-text" : {
+      "type" : "entry",
+      "default" : "Desktop",
+      "description" : "Desktop title button text"
+   },
+   "title-nowindow-text" : {
+      "type" : "entry",
+      "default" : "No Active Window",
+      "description" : "No active window title button text"
+   },
 "cinnamon-maximus-button": {
         "type": "button",
         "description": "For Maximus option, please install cinnamon-maximus extension",


### PR DESCRIPTION
Hi,

the commit message already tells it. I wasn't that happy with the hard-coded default texts in the applet, so I quickly made them configurable and thought I'd contribute that back.

Best regards
Benjamin